### PR TITLE
message on client

### DIFF
--- a/public/javascripts/traveler.js
+++ b/public/javascripts/traveler.js
@@ -369,6 +369,12 @@ $(function () {
     }
 
     binder.serializeField(input);
+
+    if (input.type === 'number' && typeof binder.accessor.target[input.name] !== 'number') {
+      $('#message').append('<div class="alert alert-error"><button class="close" data-dismiss="alert">x</button>The input value is not a number!</div>');
+      $(window).scrollTop($('#message div:last-child').offset().top - 40);
+      return;
+    }
     $.ajax({
       url: './data/',
       type: 'POST',


### PR DESCRIPTION
really interesting that both chrome and firefox do not set the value of the number input when what user input cannot be parsed as a number. So in js, `input.value` or `$(input).val()` returns `""`. There is no way to get what user just input in the field. In this sense, chrome implementation is better than firefox such that it reject any input that cannot be part of a number. 

So the best we can do is to notify the user on local. However the server side check is still required because we do not know the behavior of other browsers/versions. 