### PR TITLE
Numbering oldform 192

### DIFF
--- a/public/javascripts/form-builder.js
+++ b/public/javascripts/form-builder.js
@@ -112,6 +112,22 @@ function updateSectionNumbers() {
     });
 }
 
+function addSectionNumbers() {
+  $('#output')
+    .find('legend, .control-label')
+    .each(function() {
+      if ($(this).is('legend')) {
+        if ($(this).find('.section-number').length === 0) {
+          $(this).prepend('<span class="section-number"></span>&nbsp;');
+        }
+      } else {
+        if ($(this).find('.control-number').length === 0) {
+          $(this).prepend('<span class="control-number"></span>&nbsp;');
+        }
+      }
+    });
+}
+
 function done_button(view, $out) {
   return function(e) {
     e.preventDefault();
@@ -1270,6 +1286,20 @@ function binding_events() {
         }
       );
     }
+  });
+
+  $('#numbering').click(function(e) {
+    e.preventDefault();
+    if ($('#output .well.spec').length) {
+      modalAlert(
+        'Finish editing first',
+        'Please close all the opened edit area by clicking the "Done" button, and then generate the numbering if needed.'
+      );
+      return;
+    }
+    cleanBeforeSave();
+    addSectionNumbers();
+    updateSectionNumbers();
   });
 
   $('#preview').click(function(e) {

--- a/public/javascripts/form-builder.js
+++ b/public/javascripts/form-builder.js
@@ -95,7 +95,7 @@ function updateSectionNumbers() {
   // assign the sequence number to all legend
   $('#output')
     .find('legend, .control-label')
-    .each(function(index) {
+    .each(function() {
       if ($(this).is('legend')) {
         sectionNumber += 1;
         // reset control number

--- a/views/form-builder.jade
+++ b/views/form-builder.jade
@@ -72,6 +72,8 @@ block content
     .btn-group
       a.btn.btn-info#preview(data-toggle='tooltip', title='the form needs be saved first', href='preview', target='#{viewConfig.linkTarget}') Preview
     .btn-group
+      button.btn.btn-primary#numbering(data-toggle='tooltip', title='generate section numbers') Generate numbering
+    .btn-group
       button.btn.btn-primary#saveas(data-toggle='tooltip', title='create a copy of current form') Save as
     if (status === 0)
       .btn-group


### PR DESCRIPTION
Edit a form which was created before the numbering feature like 
<img width="811" alt="Screen Shot 2019-07-14 at 2 43 51 PM" src="https://user-images.githubusercontent.com/599397/61189750-9046ee80-a646-11e9-9e55-e0c1c41f3d0f.png">

Click on the `Generate numbering` button, and numbers will be added into the form. 
<img width="784" alt="Screen Shot 2019-07-14 at 2 44 08 PM" src="https://user-images.githubusercontent.com/599397/61189768-aeacea00-a646-11e9-8f81-1272d5773fa0.png">

Then either `save` or `save as` the updated form. 

For a traveler that was created with an old form, the form with numbers can be used with the form managers. 