### PR TITLE
change git link to official repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ For detailed deployment instructions please see https://confluence.aps.anl.gov/d
     # Make a new directory to hold the traveler module and its support
     mkdir traveler
     cd traveler
-    git clone https://github.com/iTerminate/traveler.git distribution
+    git clone https://github.com/AdvancedPhotonSource/traveler.git distribution
     cd distribution
     # Install all of the support software
     make support


### PR DESCRIPTION
might also want to put traveler-{support,mongo,ldap} in AdvancedPhotonSource ?

distribution]$ find . -xdev -type f -print0|xargs -0 -r grep -P 'github.com/(?!Adv)' |grep -v \.js|grep -vi docker
./README.md:   * traveler-mongo https://github.com/dongliu/traveler-mongo
./README.md:      git clone https://github.com/dongliu/traveler-mongo.git (to e.g., ~/git/traveler)
./README.md:   * traveler-ldap https://github.com/dongliu/traveler-ldap
./README.md:      git clone https://github.com/dongliu/traveler-ldap.git
./README.md:[MIT](https://github.com/dongliu/traveler/blob/master/LICENSE.md)
./sbin/configuration.sh:export TRAVELER_SUPPORT_GIT_URL="https://github.com/iTerminate/traveler-support.git"

-matt
