### PR TITLE
AUCS-93 Sharing of draft forms appears to be broken

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -305,6 +305,22 @@ function getCurrentUser(userid, req, res, cb) {
       } else {
         req.session.memberOf = [result.memberOf];
       }
+    } else if (ad.groupSearchBase === undefined) {
+      // Find all locally-stored groups with this user as a member
+      Group.find({"members": userid}, function(err, result) {
+        if (err) {
+          req.session.memberOf = [];
+          return;
+        }
+
+        let groups = [];
+        result.forEach(function(g) {
+          groups.push(g.name);
+        });
+        req.session.memberOf = groups;
+      });
+    } else {
+      req.session.memberOf = [];
     }
 
     // load others from db


### PR DESCRIPTION
Fix notes: req.session.memberOf was undefined when using local groups; this populates it.  In addition a failsafe was added in case ldap does not provide memberOf.