### PR TITLE
Add More Work button to completed traveler so admin can "un-approve" it.

### DIFF
--- a/model/traveler.js
+++ b/model/traveler.js
@@ -95,7 +95,7 @@ var stateTransition = [
   },
   {
     from: 2,
-    to: [4],
+    to: [4, 1],
   },
   {
     from: 3,

--- a/routes/traveler.js
+++ b/routes/traveler.js
@@ -1003,6 +1003,8 @@ module.exports = function(app) {
    * user who can write can submit the traveler for completion
    * 1.5 => 2, 1.5 => 1 :
    * only admin or manager can approve or reject submitted traveler
+   * 2 => 1:
+   * only admin or manager can return completed traveler for more work
    * 2 => 4 :
    * only admin or manager can archive approved traveler
    */
@@ -1049,8 +1051,11 @@ module.exports = function(app) {
       }
 
       if (
-        doc.status === 2 &&
-        req.body.status === 4 &&
+          (
+              (doc.status === 2 && req.body.status === 4) ||
+              (doc.status === 2 && req.body.status === 1)
+          )
+          &&
         !(
           routesUtilities.checkUserRole(req, 'admin') ||
           routesUtilities.checkUserRole(req, 'manager')

--- a/views/traveler.jade
+++ b/views/traveler.jade
@@ -77,6 +77,10 @@ block content
               when 3
                   .btn-group
                     button.btn.btn-primary#resume Resume
+              when 2
+                if (isAdmin)
+                  .btn-group
+                    button.btn.btn-warning#more More work
         if (locals.traveler.status !== undefined && locals.traveler.status > 0)
           //- .btn-group
           //-   button.btn.btn-info#update-progress Update progress


### PR DESCRIPTION
This was a request from ALS-U QA.  Without this, if a mistake is discovered in a completed traveler the only way to fix it is to create a whole new traveler.
If you don't want to include this in the APS-U version then that's fine.