### PR TITLE
Implemented the released_form_version_mgmt configuration option to he…

### DIFF
--- a/config/app_change.json
+++ b/config/app_change.json
@@ -18,5 +18,6 @@
   "upload_size": 5,
   "default_form_public_access": -1,
   "default_traveler_public_access": 0,
-  "default_binder_public_access": 0
+  "default_binder_public_access": 0,
+  "released_form_version_mgmt": 0
 }

--- a/public/javascripts/form-builder.js
+++ b/public/javascripts/form-builder.js
@@ -80,6 +80,32 @@ function sendRequest(data, cb, option) {
     .always(function() {});
 }
 
+function archive_prior_released_forms(selected) {
+  if (!selected || selected.length < 1) {
+    return;
+  }
+
+  $.ajax({
+    url: '/released-forms/archive',
+    type: 'PUT',
+    async: true,
+    data: JSON.stringify(selected),
+    contentType: 'application/json',
+    processData: false,
+  })
+      .done(function(data, textStatus, request) {
+        $('#message').append(
+            '<div class="alert alert-success"><button class="close" data-dismiss="alert"></button>' + data + '</div>'
+        );
+      })
+      .fail(function(data, textStatus, request) {
+        $('#message').append(
+            '<div class="alert alert-error"><button class="close" data-dismiss="alert"></button>' + data + '</div>'
+        );
+      })
+      .always(function() {});
+}
+
 function userkey_error($userkey, msg) {
   if (!$userkey.closest('.control-group').hasClass('error')) {
     $userkey
@@ -1443,15 +1469,42 @@ function binding_events() {
   });
 
   $('#release').click(function() {
-    var html = $('#output').html();
-    $('#modalLabel').html('Release the form');
     $('#modal .modal-body').empty();
-    var defaultTitle = $('#formtitle').text();
+    let defaultTitle = $('#formtitle').text();
     $('#modal .modal-body').append(
-      '<form class="form-horizontal" id="modalform"> <div class="control-group"> <label class="control-label">Form title</label> <div class="controls"><input id="release-title" type="text" value="' +
+        '<form class="form-horizontal" id="modalform"> <div class="control-group"> <label class="control-label">Form title</label> <div class="controls"><input id="release-title" type="text" value="' +
         defaultTitle +
         '" class="input"> </div> </div> </form>'
     );
+
+    let priorVersionsTable = null;
+    if (released_form_version_mgmt) {
+      $('#modalLabel').html('Archive previously released form(s)');
+      $('#modal .modal-body').append(
+          '<h4>Prior version(s) of this form:</h4> <table id="prior_versions" class="table table-bordered table-hover"> </table>'
+      );
+      let priorVersionsColumns = [
+        selectColumn,
+        titleColumn,
+        releasedOnColumn,
+        releasedByColumn,
+        releasedFormLinkColumn,
+      ];
+      priorVersionsTable = $('#prior_versions').dataTable({
+        sAjaxSource: '/forms/' + id + '/released/json',
+        sAjaxDataProp: '',
+        bProcessing: true,
+        oLanguage: {
+          sLoadingRecords: 'Please wait - loading data from the server ...',
+        },
+        aoColumns: priorVersionsColumns,
+        iDisplayLength: 2,
+        sDom: sDomPage,
+      });
+      selectMultiEvent(priorVersionsTable);
+      filterEvent();
+    }
+
     if (formType === 'normal') {
       $('#modal .modal-body').append(
         '<h4>Choose a discrepancy to attach</h4> <table id="discrepancy" class="table table-bordered table-hover"> </table>'
@@ -1490,6 +1543,21 @@ function binding_events() {
     );
     $('#modal').modal('show');
     $('#modal button[value="confirm"]').click(function() {
+      if (priorVersionsTable) {
+        // get all selected forms
+        let selected = fnGetSelectedInPage(
+            priorVersionsTable,
+            'row-selected',
+            false
+        );
+        let json = [];
+        $(selected).each(function(s) {
+          const data = priorVersionsTable.fnGetData(s);
+          json.push(data._id);
+        });
+        archive_prior_released_forms(json);
+      }
+
       var title = $('#release-title').val();
       var json = {
         title: title,

--- a/public/javascripts/table.js
+++ b/public/javascripts/table.js
@@ -23,6 +23,17 @@ function selectEvent() {
   });
 }
 
+function selectMultiEvent(oTable) {
+  $(oTable.$('tbody')).on('click', 'input.select-row', function(e) {
+    var tr = $(e.target).closest('tr');
+    if ($(tr).hasClass('row-selected')) {
+      $(tr).removeClass('row-selected');
+    } else {
+      $(tr).addClass('row-selected');
+    }
+  });
+}
+
 function selectOneEvent(oTable) {
   $('tbody').on('click', 'input.select-row', function(e) {
     var tr = $(e.target).closest('tr');

--- a/routes/form.js
+++ b/routes/form.js
@@ -271,6 +271,7 @@ module.exports = function(app) {
             _v: form._v,
             formType: form.formType,
             prefix: req.proxied ? req.proxied_prefix : '',
+            released_form_version_mgmt: config.app.released_form_version_mgmt,
           })
         );
       }
@@ -292,6 +293,29 @@ module.exports = function(app) {
     function(req, res) {
       return res.status(200).json(req[req.params.id]);
     }
+  );
+
+  app.get(
+      '/forms/:id/released/json',
+      auth.ensureAuthenticated,
+      reqUtils.exist('id', Form),
+      reqUtils.canReadMw('id'),
+      function(req, res) {
+          try {
+              ReleasedForm.find({
+                  'base._id': req.params.id,
+                  status: 1, // released
+              }, function (err, existingForms) {
+                  if (err) {
+                      return res.status(500).send(error.message);
+                  }
+                  debug('found ' + existingForms.length + ' previously released form(s) based on : ' + req.params.id);
+                  return res.status(200).json(existingForms);
+              });
+          } catch (error) {
+              return res.status(500).send(error.message);
+          }
+      }
   );
 
   app.post(

--- a/views/form-builder.jade
+++ b/views/form-builder.jade
@@ -18,6 +18,7 @@ block content
   script(type='text/javascript').
     var prefix = '!{prefix}';
     var id = '!{id}';
+    var released_form_version_mgmt = '!{released_form_version_mgmt}';
     var formStatus = !{JSON.stringify(locals.status)} || 0;
     var formType = !{JSON.stringify(locals.formType)} || 'normal';
   .container


### PR DESCRIPTION
…lp ensure only one version of a released form exists unless the admin user explicitly wants more than one.

  When an admin user is releasing a form and this option is turned on, the confirmation/title/discrepancy dialog also allows selecting zero or more previously released forms to be archived.